### PR TITLE
:art: Add account optional support

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,6 +13,12 @@
       "commands": [
         "dotnet-format"
       ]
+    },
+    "solana.unity.anchor.tool": {
+      "version": "0.2.8",
+      "commands": [
+        "dotnet-anchorgen"
+      ]
     }
   }
 }

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get the sources
-        uses: actions/checkout@v1
-      - name: Run the build script
-        uses: cake-build/cake-action@v1
-        with:
-          script-path: build.cake
-          target: Pack
-          cake-bootstrap: true
+        uses: actions/checkout@v2
+      - name: Run cake
+        shell: bash
+        run: |
+          dotnet tool install Cake.Tool --version 1.1.0
+          dotnet tool restore
+          dotnet cake --target=Report --verbosity=verbose

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,4 +17,4 @@ jobs:
         run: |
           dotnet tool install Cake.Tool --version 1.1.0
           dotnet tool restore
-          dotnet cake --target=Report --verbosity=verbose
+          dotnet cake --target=Test --verbosity=verbose

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 <p align="center">
-    <img src="https://raw.githubusercontent.com/garbles-labs/Solana.Unity.Anchor/master/assets/icon.png" margin="auto" height="175"/>
+    <img src="https://raw.githubusercontent.com/magicblock-labs/Solana.Unity.Anchor/master/assets/icon.png" margin="auto" height="175"/>
 </p>
 
 <p align="center">
-    <a href="https://github.com/garbles-labs/Solana.Unity.Anchor/actions/workflows/dotnet.yml">
-        <img src="https://github.com/garbles-labs/Solana.Unity.Anchor/actions/workflows/dotnet.yml/badge.svg"
+    <a href="https://github.com/magicblock-labs/Solana.Unity.Anchor/actions/workflows/dotnet.yml">
+        <img src="https://github.com/magicblock-labs/Solana.Unity.Anchor/actions/workflows/dotnet.yml/badge.svg"
             alt="Build" ></a>
-    <a href="https://github.com/garbles-labs/Solana.Unity.Anchor/actions/workflows/publish.yml">
-       <img src="https://github.com/garbles-labs/Solana.Unity.Anchor/actions/workflows/publish.yml/badge.svg" 
+    <a href="https://github.com/magicblock-labs/Solana.Unity.Anchor/actions/workflows/publish.yml">
+       <img src="https://github.com/magicblock-labs/Solana.Unity.Anchor/actions/workflows/publish.yml/badge.svg" 
             alt="Release"></a>
     <a href="">
-        <img src="https://img.shields.io/github/license/garbles-labs/Solana.Unity-Core?style=flat-square"
+        <img src="https://img.shields.io/github/license/magicblock-labs/Solana.Unity-Core?style=flat-square"
             alt="Code License"></a>
-    <a href="https://discord.gg/cReXaBReZt">
+    <a href="https://discord.com/invite/MBkdC3gxcv">
        <img alt="Discord" src="https://img.shields.io/discord/849407317761064961?style=flat-square"
             alt="Join the discussion!"></a>
 </p>
@@ -30,18 +30,16 @@ Solana.Unity.Anchor rely on [Solana.Unity-Core](https://github.com/bmresearch/So
 ## Features
 
 This repo contains 3 main projects:
-- Solnet.Anchor: IDL parsing and code generation
-- Solnet.Anchor.Tool: dotnet tool executable that interfaces with the project above.
-- Solnet.Anchor.SourceGenerator: Roslyn source generator that depends on the tool above to automatically generate code from IDL in your IDE.
+- Solana.Unity.Anchor: IDL parsing and code generation
+- Solana.Unity.Anchor.Tool: dotnet tool executable that interfaces with the project above.
+- Solana.Unity.Anchor.SourceGenerator: Roslyn source generator that depends on the tool above to automatically generate code from IDL in your IDE.
 
 Currently covers all of IDL features with the exception of events and seeds.
 
 ## Requirements
 
-Solnet.Anchor and Solnet.Anchor.Tool are compiled and run in net6. Could be easily backported to net5.
-Solnet.Anchor.SourceGenerator is compiled in netstandard2.1 to be able to be used as a Roslyn Source Generator. However, machine needs net6 as it just calls Solnet.Anchor.Tool that requires net6.
-
-Generated code can be run using net5 or net6, and the respective Solnet version >=5.0.3 or >=6.0.3 libraries.
+Solana.Unity.Anchor and Solana.Unity.Anchor.Tool are compiled and run in net6. Could be easily backported to net5.
+Solana.Unity.Anchor.SourceGenerator is compiled in netstandard2.1 to be able to be used as a Roslyn Source Generator. However, machine needs net6 as it just calls Solnet.Anchor.Tool that requires net6.
 
 ## Instructions
 
@@ -74,7 +72,11 @@ Consider supporting us:
 
 We encourage everyone to contribute, submit issues, PRs, discuss. Every kind of help is welcome.
 
-## Maintainers
+## Solana.Unity Maintainers
+
+* **Gabriele Picco** - [PiccoGabriele](https://github.com/PiccoGabriele)
+
+## Solnet Maintainers
 
 * **Hugo** - [murlokito](https://github.com/murlokito)
 * **Tiago** - [tiago](https://github.com/tiago18c)

--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <Product>Solana.Unity.Anchor</Product>
-        <Version>0.2.8</Version>
+        <Version>0.2.9</Version>
         <Copyright>Copyright 2022 &#169; Garbles Labs</Copyright>
         <Authors>Garbles Labs</Authors>
         <PublisherName>Garbles Labs</PublisherName>

--- a/Solana.Unity.Anchor.Test/Resources/seq.json
+++ b/Solana.Unity.Anchor.Test/Resources/seq.json
@@ -38,7 +38,8 @@
         {
           "name": "sequenceAccount",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "isOptional": true
         },
         {
           "name": "authority",

--- a/Solana.Unity.Anchor.Test/UnitTest1.cs
+++ b/Solana.Unity.Anchor.Test/UnitTest1.cs
@@ -1,10 +1,4 @@
-using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Solana.Unity.Anchor;
-using System.Collections.Generic;
-using System;
-using System.Buffers.Binary;
-using System.Numerics;
 
 namespace Solana.Unity.Anchor.Test
 {
@@ -18,14 +12,13 @@ namespace Solana.Unity.Anchor.Test
             var res = IdlParser.ParseFile("Resources/seq.json");
             Assert.IsNotNull(res);
 
-
-
-
             ClientGenerator c = new();
 
             c.GenerateSyntaxTree(res);
+            Assert.IsNotNull(c);
 
-
+            var code = c.GenerateCode(res);
+            Assert.IsNotNull(code);
         }
     }
 }

--- a/Solana.Unity.Anchor/ClientGenerator.cs
+++ b/Solana.Unity.Anchor/ClientGenerator.cs
@@ -156,8 +156,7 @@ namespace Solana.Unity.Anchor
                 }
                 else if (acc is IdlAccount singleAcc)
                 {
-
-
+                    
                     initExpressions.Add(InvocationExpression(
                         MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
@@ -167,10 +166,29 @@ namespace Solana.Unity.Anchor
                         IdentifierName(singleAcc.IsMut ? "Writable" : "ReadOnly")),
                     ArgumentList(SeparatedList(new ArgumentSyntax[]
                     {
-                        Argument(MemberAccessExpression(
-                            SyntaxKind.SimpleMemberAccessExpression,
-                            identifierNameSyntax,
-                            IdentifierName(singleAcc.Name.ToPascalCase()))),
+                        Argument(
+                            singleAcc.IsOptional ?
+                            ConditionalExpression(
+                        BinaryExpression(
+                                    SyntaxKind.EqualsExpression,
+                                    MemberAccessExpression(
+                                        SyntaxKind.SimpleMemberAccessExpression,
+                                        identifierNameSyntax,
+                                        IdentifierName(singleAcc.Name.ToPascalCase())),
+                                    LiteralExpression(SyntaxKind.NullLiteralExpression)
+                                    ), 
+                        
+                        IdentifierName("programId"), 
+                        MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                identifierNameSyntax,
+                                IdentifierName(singleAcc.Name.ToPascalCase()))
+                            ) : 
+                            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, 
+                                identifierNameSyntax, 
+                                IdentifierName(singleAcc.Name.ToPascalCase())
+                                )
+                        ),
                         Argument(LiteralExpression(singleAcc.IsSigner ? SyntaxKind.TrueLiteralExpression : SyntaxKind.FalseLiteralExpression))
                     }))));
 

--- a/Solana.Unity.Anchor/Models/Accounts/IdlAccount.cs
+++ b/Solana.Unity.Anchor/Models/Accounts/IdlAccount.cs
@@ -13,6 +13,8 @@ namespace Solana.Unity.Anchor.Models.Accounts
         public bool IsMut { get; set; }
 
         public bool IsSigner { get; set; }
+        
+        public bool IsOptional { get; set; }
 
         public IdlPda Pda { get; set; }
 

--- a/build.cake
+++ b/build.cake
@@ -8,11 +8,6 @@ var configuration = Argument("configuration", "Release");
 var solutionFolder = "./";
 var artifactsDir = MakeAbsolute(Directory("artifacts"));
 
-var reportTypes = "HtmlInline";
-var coverageFolder = "./code_coverage";
-var coverageFileName = "results.info";
-
-var coverageFilePath = Directory(coverageFolder) + File(coverageFileName);
 var packagesDir = artifactsDir.Combine(Directory("packages"));
 
 var deliverables = new[] {"Solana.Unity.Anchor.Tool", "Solana.Unity.Anchor.SourceGenerator"};
@@ -20,7 +15,6 @@ var deliverables = new[] {"Solana.Unity.Anchor.Tool", "Solana.Unity.Anchor.Sourc
 Task("Clean")
     .Does(() => {
         CleanDirectory(artifactsDir);
-        CleanDirectory(coverageFolder);
     });
 
 Task("Restore")


### PR DESCRIPTION
# Add account optional support

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature  | No |  - |

## Problem

Anchor added Optional Positional Accounts in https://github.com/coral-xyz/anchor/pull/2101, which add a field `isOptional` in the generated idl. Accounts marked with `isOptional` can be null while creating the instruction, the PK of the program can be used instead for creating the tx.

## Solution

Added logic to check for optional accounts and replace with the program pk if null. 