### PR TITLE
BUGFIX: Skipping accounts if none exist.

### DIFF
--- a/Solana.Unity.Anchor.Tool/AnchorSourceGenerator.cs
+++ b/Solana.Unity.Anchor.Tool/AnchorSourceGenerator.cs
@@ -46,7 +46,12 @@ public class AnchorSourceGenerator
                 var jsonParsed = JObject.Parse(idlStr);
 
                 // Set UnixTimestamp to Int64 in accounts
-                foreach (JToken account in (JArray)jsonParsed["accounts"])
+                if (!jsonParsed.TryGetValue("accounts", out JToken val))
+                {
+                    val = new JArray();
+                }
+
+                foreach (JToken account in (JArray)val)
                 {
                     JToken accountType = account["type"];
                     foreach (JObject fields in (JArray)accountType["fields"])


### PR DESCRIPTION
> ⚠️ NOTE: Use notes like this to emphasize something important about the PR.
>
>  This could include other PRs this PR is built on top of; API breaking changes; reasons for why the PR is on hold; or anything else you would like to draw attention to.

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | No | (N/A) |

## Problem
```
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at AnchorSourceGenerator.<>c.<Main>b__0_1(CommandLineOptions opts) in /Users/gabrielepicco/Documents/Solana/Solana.Unity.Anchor/Solana.Unity.Anchor.Tool/AnchorSourceGenerator.cs:line 102
   at CommandLine.ParserResultExtensions.MapResult[TSource,TResult](ParserResult`1 result, Func`2 parsedFunc, Func`2 notParsedFunc)
   at AnchorSourceGenerator.Main(String[] args) in /Users/gabrielepicco/Documents/Solana/Solana.Unity.Anchor/Solana.Unity.Anchor.Tool/AnchorSourceGenerator
```
Building simple Anchor programs solely using token accounts from `anchor-spl` will require no additional structs with  
`#[account]` attribute. The parser throws an exception when unable to find the "accounts" attribute in the JSON IDL.

Even an empty Anchor project may be affected (not tested).

## Workaround
Add a dummy struct to the Anchor program for populating the IDL fields. For example:
```
#[account]
pub struct Dummy{
    pub data: u64,
}
```

## Solution

Skip "accounts" token if missing in the IDL.
