### PR TITLE
:sparkles: Add support for newer IDL standard

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <Product>Solana.Unity.Anchor</Product>
-        <Version>0.2.11</Version>
+        <Version>0.2.12</Version>
         <Copyright>Copyright 2023 &#169; Magicblock</Copyright>
         <Authors>Magicblock</Authors>
         <PublisherName>Magicblock</PublisherName>

--- a/Solana.Unity.Anchor.Test/Resources/PlayerData.json
+++ b/Solana.Unity.Anchor.Test/Resources/PlayerData.json
@@ -1,0 +1,227 @@
+{
+  "address": "EragBXpF9jU2fxZh2FQC4ZWksrxkujdwcx6mcU5CoRB3",
+  "metadata": {
+    "name": "playerdata",
+    "version": "0.1.5",
+    "spec": "0.1.0",
+    "description": "Created with Bolt"
+  },
+  "instructions": [
+    {
+      "name": "initialize",
+      "discriminator": [
+        175,
+        175,
+        109,
+        31,
+        13,
+        152,
+        155,
+        237
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "data",
+          "writable": true
+        },
+        {
+          "name": "entity"
+        },
+        {
+          "name": "authority"
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "update",
+      "discriminator": [
+        219,
+        200,
+        88,
+        176,
+        158,
+        63,
+        253,
+        127
+      ],
+      "accounts": [
+        {
+          "name": "bolt_component",
+          "writable": true
+        },
+        {
+          "name": "authority"
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "data",
+          "type": "bytes"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Entity",
+      "discriminator": [
+        46,
+        157,
+        161,
+        161,
+        254,
+        46,
+        79,
+        24
+      ]
+    },
+    {
+      "name": "PlayerData",
+      "discriminator": [
+        197,
+        65,
+        216,
+        202,
+        43,
+        139,
+        147,
+        128
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "PlayerDataNotInitialized",
+      "msg": "Player Data is not initialized."
+    },
+    {
+      "code": 6001,
+      "name": "PlayerDataAlreadyInitialized",
+      "msg": "Player Data cannot be initialized multiple times."
+    },
+    {
+      "code": 6002,
+      "name": "InvalidOwner",
+      "msg": "Signer did not have authority over entity."
+    },
+    {
+      "code": 6003,
+      "name": "NotActive",
+      "msg": "Player not active in world"
+    }
+  ],
+  "types": [
+    {
+      "name": "BoltMetadata",
+      "docs": [
+        "Metadata for the component."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Entity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "id",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Heading",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "North"
+          },
+          {
+            "name": "East"
+          },
+          {
+            "name": "South"
+          },
+          {
+            "name": "West"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PlayerData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "is_active",
+            "type": "bool"
+          },
+          {
+            "name": "owner",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "world_pos_x",
+            "type": {
+              "option": "i32"
+            }
+          },
+          {
+            "name": "world_pos_y",
+            "type": {
+              "option": "i32"
+            }
+          },
+          {
+            "name": "heading",
+            "type": {
+              "defined": {
+                "name": "Heading"
+              }
+            }
+          },
+          {
+            "name": "bolt_metadata",
+            "type": {
+              "defined": {
+                "name": "BoltMetadata"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/Solana.Unity.Anchor.Test/Resources/World.json
+++ b/Solana.Unity.Anchor.Test/Resources/World.json
@@ -1,0 +1,462 @@
+{
+  "version": "0.1.1",
+  "name": "world",
+  "instructions": [
+    {
+      "name": "initializeRegistry",
+      "accounts": [
+        {
+          "name": "registry",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initializeNewWorld",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "world",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "registry",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "addEntity",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "entity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "world",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "extraSeed",
+          "type": {
+            "option": "string"
+          }
+        }
+      ]
+    },
+    {
+      "name": "initializeComponent",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "data",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "entity",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "componentProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "apply",
+      "accounts": [
+        {
+          "name": "componentProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltSystem",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltComponent",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "apply2",
+      "accounts": [
+        {
+          "name": "boltSystem",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "componentProgram1",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltComponent1",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "componentProgram2",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltComponent2",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "apply3",
+      "accounts": [
+        {
+          "name": "boltSystem",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "componentProgram1",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltComponent1",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "componentProgram2",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltComponent2",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "componentProgram3",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltComponent3",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "apply4",
+      "accounts": [
+        {
+          "name": "boltSystem",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "componentProgram1",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltComponent1",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "componentProgram2",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltComponent2",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "componentProgram3",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltComponent3",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "componentProgram4",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltComponent4",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "apply5",
+      "accounts": [
+        {
+          "name": "boltSystem",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "componentProgram1",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltComponent1",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "componentProgram2",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltComponent2",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "componentProgram3",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltComponent3",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "componentProgram4",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltComponent4",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "componentProgram5",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "boltComponent5",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Entity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "id",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Registry",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "worlds",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "World",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "id",
+            "type": "u64"
+          },
+          {
+            "name": "entities",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidAuthority",
+      "msg": "Invalid authority for instruction"
+    }
+  ],
+  "metadata": {
+    "address": "WorLD15A7CrDwLcLy4fRqtaTb9fbd8o8iqiEMUDse2n",
+    "origin": "anchor",
+    "binaryVersion": "0.29.0",
+    "libVersion": "0.29.0"
+  }
+}

--- a/Solana.Unity.Anchor.Test/Resources/WorldNew.json
+++ b/Solana.Unity.Anchor.Test/Resources/WorldNew.json
@@ -1,0 +1,517 @@
+{
+  "address": "WorLD15A7CrDwLcLy4fRqtaTb9fbd8o8iqiEMUDse2n",
+  "metadata": {
+    "name": "world",
+    "version": "0.1.4",
+    "spec": "0.1.0",
+    "description": "Bolt World program",
+    "repository": "https://github.com/magicblock-labs/bolt"
+  },
+  "instructions": [
+    {
+      "name": "add_entity",
+      "discriminator": [
+        163,
+        241,
+        57,
+        35,
+        244,
+        244,
+        48,
+        57
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "entity",
+          "writable": true
+        },
+        {
+          "name": "world",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "extra_seed",
+          "type": {
+            "option": "string"
+          }
+        }
+      ]
+    },
+    {
+      "name": "apply",
+      "discriminator": [
+        248,
+        243,
+        145,
+        24,
+        105,
+        50,
+        162,
+        225
+      ],
+      "accounts": [
+        {
+          "name": "component_program"
+        },
+        {
+          "name": "bolt_system"
+        },
+        {
+          "name": "bolt_component",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "apply2",
+      "discriminator": [
+        120,
+        32,
+        116,
+        154,
+        158,
+        159,
+        208,
+        73
+      ],
+      "accounts": [
+        {
+          "name": "bolt_system"
+        },
+        {
+          "name": "component_program_1"
+        },
+        {
+          "name": "bolt_component_1",
+          "writable": true
+        },
+        {
+          "name": "component_program_2"
+        },
+        {
+          "name": "bolt_component_2",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "apply3",
+      "discriminator": [
+        254,
+        146,
+        49,
+        7,
+        236,
+        131,
+        105,
+        221
+      ],
+      "accounts": [
+        {
+          "name": "bolt_system"
+        },
+        {
+          "name": "component_program_1"
+        },
+        {
+          "name": "bolt_component_1",
+          "writable": true
+        },
+        {
+          "name": "component_program_2"
+        },
+        {
+          "name": "bolt_component_2",
+          "writable": true
+        },
+        {
+          "name": "component_program_3"
+        },
+        {
+          "name": "bolt_component_3",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "apply4",
+      "discriminator": [
+        223,
+        104,
+        24,
+        79,
+        252,
+        196,
+        14,
+        109
+      ],
+      "accounts": [
+        {
+          "name": "bolt_system"
+        },
+        {
+          "name": "component_program_1"
+        },
+        {
+          "name": "bolt_component_1",
+          "writable": true
+        },
+        {
+          "name": "component_program_2"
+        },
+        {
+          "name": "bolt_component_2",
+          "writable": true
+        },
+        {
+          "name": "component_program_3"
+        },
+        {
+          "name": "bolt_component_3",
+          "writable": true
+        },
+        {
+          "name": "component_program_4"
+        },
+        {
+          "name": "bolt_component_4",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "apply5",
+      "discriminator": [
+        70,
+        164,
+        214,
+        28,
+        136,
+        116,
+        84,
+        153
+      ],
+      "accounts": [
+        {
+          "name": "bolt_system"
+        },
+        {
+          "name": "component_program_1"
+        },
+        {
+          "name": "bolt_component_1",
+          "writable": true
+        },
+        {
+          "name": "component_program_2"
+        },
+        {
+          "name": "bolt_component_2",
+          "writable": true
+        },
+        {
+          "name": "component_program_3"
+        },
+        {
+          "name": "bolt_component_3",
+          "writable": true
+        },
+        {
+          "name": "component_program_4"
+        },
+        {
+          "name": "bolt_component_4",
+          "writable": true
+        },
+        {
+          "name": "component_program_5"
+        },
+        {
+          "name": "bolt_component_5",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "initialize_component",
+      "discriminator": [
+        36,
+        143,
+        233,
+        113,
+        12,
+        234,
+        61,
+        30
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "data",
+          "writable": true
+        },
+        {
+          "name": "entity"
+        },
+        {
+          "name": "component_program"
+        },
+        {
+          "name": "authority"
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_new_world",
+      "discriminator": [
+        23,
+        96,
+        88,
+        194,
+        200,
+        203,
+        200,
+        98
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "world",
+          "writable": true
+        },
+        {
+          "name": "registry",
+          "writable": true,
+          "address": "EHLkWwAT9oebVv9ht3mtqrvHhRVMKrt54tF3MfHTey2K"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_registry",
+      "discriminator": [
+        189,
+        181,
+        20,
+        17,
+        174,
+        57,
+        249,
+        59
+      ],
+      "accounts": [
+        {
+          "name": "registry",
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Entity",
+      "discriminator": [
+        46,
+        157,
+        161,
+        161,
+        254,
+        46,
+        79,
+        24
+      ]
+    },
+    {
+      "name": "Registry",
+      "discriminator": [
+        47,
+        174,
+        110,
+        246,
+        184,
+        182,
+        252,
+        218
+      ]
+    },
+    {
+      "name": "World",
+      "discriminator": [
+        145,
+        45,
+        170,
+        174,
+        122,
+        32,
+        155,
+        124
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidAuthority",
+      "msg": "Invalid authority for instruction"
+    },
+    {
+      "code": 6001,
+      "name": "WorldAccountMismatch",
+      "msg": "The provided world account does not match the expected PDA."
+    }
+  ],
+  "types": [
+    {
+      "name": "Entity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "id",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Registry",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "worlds",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "World",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "id",
+            "type": "u64"
+          },
+          {
+            "name": "entities",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/Solana.Unity.Anchor.Test/Solana.Unity.Anchor.Test.csproj
+++ b/Solana.Unity.Anchor.Test/Solana.Unity.Anchor.Test.csproj
@@ -33,6 +33,15 @@
     <None Update="Resources\Empty.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\PlayerData.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\World.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\WorldNew.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Solana.Unity.Anchor.Test/UnitTest1.cs
+++ b/Solana.Unity.Anchor.Test/UnitTest1.cs
@@ -50,6 +50,51 @@ namespace Solana.Unity.Anchor.Test
             var code = c.GenerateCode(res);
             Assert.IsNotNull(code);
         }
+        
+        [TestMethod]
+        public void TestNewIdlStandard()
+        {
+            var res = IdlParser.ParseFile("Resources/PlayerData.json");
+            Assert.IsNotNull(res);
+
+            ClientGenerator c = new();
+
+            c.GenerateSyntaxTree(res);
+            Assert.IsNotNull(c);
+
+            var code = c.GenerateCode(res);
+            Assert.IsNotNull(code);
+        }
+        
+        [TestMethod]
+        public void TestBoltWorldProgramParsing()
+        {
+            var res = IdlParser.ParseFile("Resources/World.json");
+            Assert.IsNotNull(res);
+
+            ClientGenerator c = new();
+
+            c.GenerateSyntaxTree(res);
+            Assert.IsNotNull(c);
+
+            var code = c.GenerateCode(res);
+            Assert.IsNotNull(code);
+        }
+        
+        [TestMethod]
+        public void TestBoltWorldNewProgramParsing()
+        {
+            var res = IdlParser.ParseFile("Resources/WorldNew.json");
+            Assert.IsNotNull(res);
+
+            ClientGenerator c = new();
+
+            c.GenerateSyntaxTree(res);
+            Assert.IsNotNull(c);
+
+            var code = c.GenerateCode(res);
+            Assert.IsNotNull(code);
+        }
     }
 }
 

--- a/Solana.Unity.Anchor.Tool/AnchorSourceGenerator.cs
+++ b/Solana.Unity.Anchor.Tool/AnchorSourceGenerator.cs
@@ -29,7 +29,7 @@ public class AnchorSourceGenerator
                 }
                 else
                 {
-                    idlStr = IdlRetriever.GetIdl(new(opts.Address), GetRpcClient(opts.Network));
+                    idlStr = IdlRetriever.GetIdl(new(opts.Address), GetRpcClient(opts.Network)).Result;
                 }
 
                 if (idlStr == null)

--- a/Solana.Unity.Anchor.Tool/Solana.Unity.Anchor.Tool.csproj
+++ b/Solana.Unity.Anchor.Tool/Solana.Unity.Anchor.Tool.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="Solana.Unity.Rpc" Version="2.6.0.9" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Solana.Unity.Rpc" Version="2.6.1.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Solana.Unity.Anchor/Converters/IIdlAccountItemConverter.cs
+++ b/Solana.Unity.Anchor/Converters/IIdlAccountItemConverter.cs
@@ -1,6 +1,7 @@
 ﻿using Solana.Unity.Anchor.Models.Accounts;
 using Solana.Unity.Anchor.Models.Types;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,61 +15,8 @@ namespace Solana.Unity.Anchor.Converters
     {
         public override IIdlAccountItem[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.StartArray) return null;
-
-            List<IIdlAccountItem> accountItems = new List<IIdlAccountItem>();
-
-            reader.Read();
-            
-
-            while (reader.TokenType == JsonTokenType.StartObject)
-            {
-                Utf8JsonReader readerCopy = reader;
-                //IIdlAccountItem acc = 
-
-                reader.Read();
-                if (reader.TokenType != JsonTokenType.PropertyName) throw new JsonException("Unexpected error value.");
-
-                string propertyName = reader.GetString();
-                if ("name" != propertyName) throw new JsonException("Unexpected error value.");
-
-                reader.Read();
-                if (reader.TokenType != JsonTokenType.String) throw new JsonException("Unexpected error value.");
-
-                string name = reader.GetString();
-
-                reader.Read();
-                if (reader.TokenType != JsonTokenType.PropertyName) throw new JsonException("Unexpected error value.");
-
-                propertyName = reader.GetString();
-                reader.Read();
-
-                if ("accounts" == propertyName)
-                {
-                    IdlAccounts accounts = new();
-                    accounts.Name = name;
-
-                    accounts.Accounts = Read(ref reader, typeToConvert, options);
-                    accountItems.Add(accounts);
-                }
-                else
-                {
-                    IdlAccount account = JsonSerializer.Deserialize<IdlAccount>(ref readerCopy, options);
-
-                    accountItems.Add(account);
-                    
-                    reader = readerCopy;
-                }
-
-                // object end
-                if(reader.TokenType != JsonTokenType.EndObject)
-                    reader.Read();
-                reader.Read();
-                
-            }
-            //array end
-            //reader.Read();
-            return accountItems.ToArray();
+            List<IdlAccount> accountItems = JsonSerializer.Deserialize<List<IdlAccount>>(ref reader, options);
+            return accountItems.Cast<IIdlAccountItem>().ToArray();
         }
 
         public override void Write(Utf8JsonWriter writer, IIdlAccountItem[] value, JsonSerializerOptions options)

--- a/Solana.Unity.Anchor/Converters/IIdlTypeConverter.cs
+++ b/Solana.Unity.Anchor/Converters/IIdlTypeConverter.cs
@@ -1,12 +1,8 @@
 ﻿using Solana.Unity.Anchor.Models.Types;
 using Solana.Unity.Anchor.Models.Types.Base;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
 namespace Solana.Unity.Anchor.Converters
 {
@@ -23,6 +19,7 @@ namespace Solana.Unity.Anchor.Converters
                 {
                     "string" => new IdlString(),
                     "publicKey" => new IdlPublicKey(),
+                    "pubkey" => new IdlPublicKey(),
                     "bytes" => new IdlArray() { ValuesType = new IdlValueType() { TypeName = "u8" } },
                     "u128" or "i128" => new IdlBigInt() { TypeName = typeName },
                     "UnixTimestamp" => new UnixTimestamp(),
@@ -39,10 +36,21 @@ namespace Solana.Unity.Anchor.Converters
                 if ("defined" == typeName)
                 {
                     reader.Read();
+                    var readDefinedObj = false;
+                    if (reader.TokenType == JsonTokenType.StartObject)
+                    {
+                        reader.Read();
+                        if (reader.TokenType != JsonTokenType.PropertyName) throw new JsonException("Unexpected error value.");
+                        string propertyName = reader.GetString();
+                        if ("name" != propertyName) throw new JsonException("Unexpected error value.");
+                        reader.Read();
+                        readDefinedObj = true;
+                    }
                     if (reader.TokenType != JsonTokenType.String) throw new JsonException("Unexpected error value.");
                     string definedTypeName = reader.GetString();
                     
                     reader.Read();
+                    if (reader.TokenType == JsonTokenType.EndObject && readDefinedObj) reader.Read();
                     return new IdlDefined() { TypeName = definedTypeName };
                 }
                 else if ("option" == typeName)

--- a/Solana.Unity.Anchor/Converters/IIdlTypeNameConverter.cs
+++ b/Solana.Unity.Anchor/Converters/IIdlTypeNameConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Solana.Unity.Anchor.Converters
+{
+    public class IIdlTypeNameConverter : JsonConverter<string>
+    {
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.PropertyName && reader.GetString() == "name")
+                    {
+                        reader.Read();
+                        return reader.GetString();
+                    }
+                }
+            }
+            else if (reader.TokenType == JsonTokenType.String)
+            {
+                return reader.GetString();
+            }
+
+            throw new JsonException("Unable to parse the 'name' property.");
+        }
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(writer, value, options);
+        }
+    }
+}

--- a/Solana.Unity.Anchor/IdlRetriever.cs
+++ b/Solana.Unity.Anchor/IdlRetriever.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Solana.Unity.Anchor
 {
@@ -12,13 +13,13 @@ namespace Solana.Unity.Anchor
     {
         private const string IDL_SEED = "anchor:idl";
         
-        public static string GetIdl(PublicKey program, IRpcClient client = default)
+        public static async Task<string> GetIdl(PublicKey program, IRpcClient client = default)
         {
             client ??= ClientFactory.GetClient(Cluster.MainNet);
 
             var address = GetIdlAccount(program);
 
-            var res = client.GetAccountInfo(address);
+            var res = await client.GetAccountInfoAsync(address);
 
             if(!res.WasSuccessful || res.Result.Value == null || res.Result.Value.Data == null)
             {

--- a/Solana.Unity.Anchor/Models/Accounts/IdlAccount.cs
+++ b/Solana.Unity.Anchor/Models/Accounts/IdlAccount.cs
@@ -1,4 +1,5 @@
 ﻿using Solana.Unity.Anchor.CodeGen;
+using System.Text.Json.Serialization;
 
 namespace Solana.Unity.Anchor.Models.Accounts
 {
@@ -6,15 +7,35 @@ namespace Solana.Unity.Anchor.Models.Accounts
     {
         public string Name { get; set; }
         
+        public string Address { get; set; }
+        
         public string Description { get; set; }
 
         public string NamePascalCase => Name.ToPascalCase();
 
         public bool IsMut { get; set; }
+        
+        [JsonPropertyName("writable")]
+        public bool IsWritable { get; set; }
+        
+        [JsonIgnore]
+        public bool Writable => IsMut || IsWritable;
 
         public bool IsSigner { get; set; }
         
+        [JsonPropertyName("signer")]
+        public bool IsSignerNew { get; set; }
+        
+        [JsonIgnore]
+        public bool Signer => IsSigner || IsSignerNew;
+        
         public bool IsOptional { get; set; }
+        
+        [JsonPropertyName("optional")]
+        public bool IsOptionalNew { get; set; }
+        
+        [JsonIgnore]
+        public bool Optional => IsOptional || IsOptionalNew;
 
         public IdlPda Pda { get; set; }
 

--- a/Solana.Unity.Anchor/Models/Idl.cs
+++ b/Solana.Unity.Anchor/Models/Idl.cs
@@ -14,12 +14,21 @@ namespace Solana.Unity.Anchor.Models
     public class Idl
     {
         [JsonIgnore]
+        public string Address => DefaultProgramAddress ?? Metadata?.Address;
+        
+        [JsonPropertyName("address")]
         public string DefaultProgramAddress { get; set; }
 
         public string Version { get; set; }
-        public string Name { get; set; }
+        
+        [JsonIgnore]
+        public string Name => NameDirect ?? Metadata?.Name;
 
-        public string NamePascalCase => Name.ToPascalCase();
+        [JsonInclude]
+        [JsonPropertyName("name")]
+        public string NameDirect { get; set; }
+
+        public string NamePascalCase => Name?.ToPascalCase();
 
         public IdlInstruction[] Instructions { get; set; }
 
@@ -33,7 +42,8 @@ namespace Solana.Unity.Anchor.Models
         public IdlErrorCode[] Errors { get; set; }
 
         public IdlEvent[] Events { get; set; }
-
+        
+        public Metadata Metadata { get; set; }
     }
 
 }

--- a/Solana.Unity.Anchor/Models/IdlInstruction.cs
+++ b/Solana.Unity.Anchor/Models/IdlInstruction.cs
@@ -19,7 +19,8 @@ namespace Solana.Unity.Anchor.Models
 
         [JsonConverter(typeof(IIdlAccountItemConverter))]
         public IIdlAccountItem[] Accounts { get; set; }
-
+        
+        public List<byte> Discriminator { get; set; }
         public IdlField[] Args { get; set; }
     }
 }

--- a/Solana.Unity.Anchor/Models/Metadata.cs
+++ b/Solana.Unity.Anchor/Models/Metadata.cs
@@ -1,0 +1,10 @@
+namespace Solana.Unity.Anchor.Models;
+
+public class Metadata
+{
+    public string Name { get; set; }
+    public string Address { get; set; }
+    public string Version { get; set; }
+    public string Spec { get; set; }
+    public string Description { get; set; }
+}

--- a/Solana.Unity.Anchor/Models/Types/Struct/StructIdlTypeDefinition.cs
+++ b/Solana.Unity.Anchor/Models/Types/Struct/StructIdlTypeDefinition.cs
@@ -1,9 +1,4 @@
-﻿using Solana.Unity.Anchor.CodeGen;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Solana.Unity.Anchor.Models.Types
 {
@@ -12,5 +7,6 @@ namespace Solana.Unity.Anchor.Models.Types
         public string Name { get; set; }
 
         public IdlField[] Fields { get; set; }
+        public List<byte> Discriminator { get; set; }
     }
 }

--- a/Solana.Unity.Anchor/Solana.Unity.Anchor.csproj
+++ b/Solana.Unity.Anchor/Solana.Unity.Anchor.csproj
@@ -6,9 +6,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
-		<PackageReference Include="Solana.Unity.Programs" Version="2.6.0.9" />
-		<PackageReference Include="Solana.Unity.Rpc" Version="2.6.0.9" />
-		<PackageReference Include="Solana.Unity.Wallet" Version="2.6.0.9" />
+		<PackageReference Include="Solana.Unity.Programs" Version="2.6.1.3" />
+		<PackageReference Include="Solana.Unity.Rpc" Version="2.6.1.3" />
+		<PackageReference Include="Solana.Unity.Wallet" Version="2.6.1.3" />
 	</ItemGroup>
 
 	<Import Project="..\SharedBuildProperties.props" />


### PR DESCRIPTION
# Add support for the new IDL standard

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature  | Yes | - |

## Problem

The IDL generator was incompatible with the new specification defined in Anchor 0.30.0: https://github.com/coral-xyz/anchor/pull/2824

## Solution

- Add parsing support for the newer standard
- Add support for custom account/instruction discriminators, addresses and additional fields
- The parser can now work with both specification, producing valid C# code

## Consideration

Not all the features of the new IDL standard are currently supported, e.g. serialization/deserialization different from Borsh. This requires a bigger rewrite/update of the generator tool