### PR TITLE
:sparkles: Upgrading to .NET8

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
           
       - name: Get the sources
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
       - name: Get the sources
         uses: actions/checkout@v4
       - name: build, pack & publish

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Currently covers all of IDL features with the exception of events and seeds.
 
 ## Requirements
 
-Solana.Unity.Anchor and Solana.Unity.Anchor.Tool are compiled and run in net6. Could be easily backported to net5.
-Solana.Unity.Anchor.SourceGenerator is compiled in netstandard2.1 to be able to be used as a Roslyn Source Generator. However, machine needs net6 as it just calls Solnet.Anchor.Tool that requires net6.
+Solana.Unity.Anchor and Solana.Unity.Anchor.Tool are compiled and run in net8. Could be easily backported to net5.
+Solana.Unity.Anchor.SourceGenerator is compiled in netstandard2.1 to be able to be used as a Roslyn Source Generator. However, machine needs net8 as it just calls Solnet.Anchor.Tool that requires net8.
 
 ## Instructions
 

--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <Product>Solana.Unity.Anchor</Product>
-        <Version>0.2.15</Version>
+        <Version>0.2.16</Version>
         <Copyright>Copyright 2023 &#169; Magicblock</Copyright>
         <Authors>Magicblock</Authors>
         <PublisherName>Magicblock</PublisherName>
@@ -11,7 +11,7 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageIcon>icon.png</PackageIcon>
         <PackageDescription>Solana.Unity.AnchorUnity is a set of tools to integrate with Solana Anchor programs.</PackageDescription>
-        <PackageTags>solana;solnet;sol;net6;spl;anchor;unity</PackageTags>
+        <PackageTags>solana;solnet;sol;net8;spl;anchor;unity</PackageTags>
         <PackageReleaseNotes>https://github.com/garbles-labs/Solana.Unity.Anchor/releases</PackageReleaseNotes>
         <RepositoryType>git</RepositoryType>
     </PropertyGroup>

--- a/Solana.Unity.Anchor.Examples/Solana.Unity.Anchor.Examples.csproj
+++ b/Solana.Unity.Anchor.Examples/Solana.Unity.Anchor.Examples.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 		<AnchorGenerator>JPv1rCqrhagNNmJVM5J1he7msQ5ybtvE1nNuHpDHMNU,SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f</AnchorGenerator>
     </PropertyGroup>
 

--- a/Solana.Unity.Anchor.Test/Solana.Unity.Anchor.Test.csproj
+++ b/Solana.Unity.Anchor.Test/Solana.Unity.Anchor.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Solana.Unity.Anchor.Tool/Solana.Unity.Anchor.Tool.csproj
+++ b/Solana.Unity.Anchor.Tool/Solana.Unity.Anchor.Tool.csproj
@@ -6,7 +6,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<StartupObject>AnchorSourceGenerator</StartupObject>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>dotnet-anchorgen</ToolCommandName>

--- a/Solana.Unity.Anchor/Solana.Unity.Anchor.csproj
+++ b/Solana.Unity.Anchor/Solana.Unity.Anchor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | None |

## Problem

`Ubuntu 24.04` no longer ships `.NET 6.0`.

## Solution

Upgrade project to `.NET 8.0`